### PR TITLE
Split XML processing apart from downloading

### DIFF
--- a/R/pmcOAI.R
+++ b/R/pmcOAI.R
@@ -31,6 +31,12 @@ pmcOAI <- function(id,  ...){
       x <- getURL( paste0(url, id2), .encoding="UTF-8", ...)
   
    }
+
+   doc <- processXML(x)
+   doc
+}
+
+processXML <- function(xmlFile, id=NULL, file=NULL) {
    # Remove namespace for easier XPath queries
 #   x[1] <- gsub(" xmlns=[^ ]*" , "", x[1])
 # see PMC4515827 with tab before xmlns,  \txmlns=
@@ -43,10 +49,15 @@ pmcOAI <- function(id,  ...){
    x[n] <- gsub(">([^<])</xref>", ">^\\1</xref>", x[n])
 
    doc <- xmlParse(x)  
- 
+
    ## ADD attributes  
-   attr(doc, "id") <- id
-   attr(doc, "file") <- file
+   if (id) {
+    attr(doc, "id") <- id
+   }
+
+   if (file) {
+    attr(doc, "file") <- file
+   }
+
    doc
 }
-

--- a/R/pmcOAI.R
+++ b/R/pmcOAI.R
@@ -1,6 +1,6 @@
 # Get XML from PMC-OAI service  (Pubmed Central Open Archives Initiative)
 
-# http://www.ncbi.nlm.nih.gov/pmc/tools/oai/
+# https://www.ncbi.nlm.nih.gov/pmc/tools/oai/
 
 pmcOAI <- function(id,  ...){
   
@@ -11,11 +11,11 @@ pmcOAI <- function(id,  ...){
    id2 <- gsub("PMC", "", id)
 
    # file name for attributes
-   file  <- paste("http://www.ncbi.nlm.nih.gov/pmc/articles/", id, sep="")
+   file  <- paste("https://www.ncbi.nlm.nih.gov/pmc/articles/", id, sep="")
  
    # use getURL in RCurl package (readlines returns incomplete line warning and does not get errors (just 404 NOT found)
-  #  url <- "http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=GetRecord&metadataPrefix=pmc&identifier=oai:pubmedcentral.nih.gov:"   
-     url <- "http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=GetRecord&metadataPrefix=pmc&identifier=oai:pubmedcentral.nih.gov:"
+  #  url <- "https://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=GetRecord&metadataPrefix=pmc&identifier=oai:pubmedcentral.nih.gov:"   
+     url <- "https://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=GetRecord&metadataPrefix=pmc&identifier=oai:pubmedcentral.nih.gov:"
 
    x <- getURL( paste0(url, id2), .encoding="UTF-8", ...)
    
@@ -25,8 +25,8 @@ pmcOAI <- function(id,  ...){
       if(error=="idDoesNotExist") stop("No results found using ", id)
 
       message("No full text in Open Access Subset, downloading metadata only" )        
-    #  url <- "http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=GetRecord&metadataPrefix=pmc_fm&identifier=oai:pubmedcentral.nih.gov:"
-       url <- "http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=GetRecord&metadataPrefix=pmc_fm&identifier=oai:pubmedcentral.nih.gov:"
+    #  url <- "https://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=GetRecord&metadataPrefix=pmc_fm&identifier=oai:pubmedcentral.nih.gov:"
+       url <- "https://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=GetRecord&metadataPrefix=pmc_fm&identifier=oai:pubmedcentral.nih.gov:"
 
       x <- getURL( paste0(url, id2), .encoding="UTF-8", ...)
   

--- a/R/pmcOAI.R
+++ b/R/pmcOAI.R
@@ -51,11 +51,11 @@ processXML <- function(x, id=NULL, file=NULL) {
    doc <- xmlParse(x)  
 
    ## ADD attributes  
-   if (id) {
+   if (!is.null(id)) {
     attr(doc, "id") <- id
    }
 
-   if (file) {
+   if (!is.null(file)) {
     attr(doc, "file") <- file
    }
 

--- a/R/pmcOAI.R
+++ b/R/pmcOAI.R
@@ -36,7 +36,7 @@ pmcOAI <- function(id,  ...){
    doc
 }
 
-processXML <- function(xmlFile, id=NULL, file=NULL) {
+processXML <- function(x, id=NULL, file=NULL) {
    # Remove namespace for easier XPath queries
 #   x[1] <- gsub(" xmlns=[^ ]*" , "", x[1])
 # see PMC4515827 with tab before xmlns,  \txmlns=


### PR DESCRIPTION
After this PR, pmcOAI has a new function called `processXML` that does the actual processing of XML files that used to happen after downloading inside of `pmcOAI`. `pmcOAI` continues to work as before, but the new function can be used to efficiently process pre-downloaded XML files.